### PR TITLE
Population lookups temporary workaround

### DIFF
--- a/geography_lookup.R
+++ b/geography_lookup.R
@@ -103,9 +103,6 @@ hscp_loc <- readRDS(paste0(geo_lookup, "HSCP Localities_DZ11_Lookup_20220630.rds
   select(datazone2011, hscp_locality, hscp2019name) 
 
 
-
-
-
 # Update November 2021: in the latest update of the lookup, 'Renfrewshire North West 
 # and South' has been updated to 'West Renfrewshire' - this needs to be renamed 
 # so that the alphabetical order of localities is the same and it is given the 

--- a/geography_lookup.R
+++ b/geography_lookup.R
@@ -10,6 +10,7 @@
 #Part 4 - Parent geography for IZ and locality
 #Part 5 - Create dictionary  to have the names and not codes.
 #Part 6 - Deprivation (SIMD) geographies
+
 ###############################################.
 ## Packages and filepaths ----
 ###############################################.
@@ -20,18 +21,13 @@ library(jsonlite)  # transforming JSON files into dataframes
 library(tidyr)
 library(magrittr)
 
+
 # Varies filepaths depending on if using server or not and what organisation uses it.
-if (exists("organisation") == TRUE) { #Health Scotland
-  if (organisation == "HS") { 
-    geo_lookup <- "X:/ScotPHO Profiles/Data/Lookups/Geography/"
-  }
-} else  { #ISD, first server then desktop
   if (sessionInfo()$platform %in% c("x86_64-redhat-linux-gnu (64-bit)", "x86_64-pc-linux-gnu (64-bit)")) {
     geo_lookup <- "/PHI_conf/ScotPHO/Profiles/Data/Lookups/Geography/"
   } else  {
     geo_lookup <- "//stats/ScotPHO/Profiles/Data/Lookups/Geography/"
   }
-}
 
 ###############################################.
 ## Functions ----

--- a/population_lookup.R
+++ b/population_lookup.R
@@ -169,8 +169,10 @@ rm(dz01_base) #freeing up memory
 # # Resource ids can be accessed in the page for the datazone 2011 pop here:
 # https://www.opendata.nhs.scot/dataset/population-estimates
 # This is slower and fails more than the second method
-dz11_base <- extract_open_data("c505f490-c201-44bd-abd1-1bd7a64285ee", datazone) %>% 
-  create_agegroups()  %>% rename(denominator = pop, datazone2011 =code)
+# dz11_base <- extract_open_data("c505f490-c201-44bd-abd1-1bd7a64285ee", datazone) %>% 
+#   create_agegroups()  %>% rename(denominator = pop, datazone2011 =code)
+
+# Alternative code chunk (the function to open files and manipulation direct from API doesn't like running in posit ?too memory intensive?)
 # If the previous one times out/fails try this, but the link might change every year
 dz11_base <- read_csv("https://www.opendata.nhs.scot/dataset/7f010430-6ce1-4813-b25c-f7f335bdc4dc/resource/c505f490-c201-44bd-abd1-1bd7a64285ee/download/dz2011-pop-est_07092021.csv") %>%
   setNames(tolower(names(.))) %>%   #variables to lower case
@@ -182,8 +184,18 @@ dz11_base <- read_csv("https://www.opendata.nhs.scot/dataset/7f010430-6ce1-4813-
   create_agegroups()  %>%
   rename(sex_grp = sex, denominator = pop, datazone2011 = datazone)
 
+##temporary fix for delayed 2022 SAPE 
+#recycle 2021 populations as if they were the new 2022 populations - this will need to be revised & reupdated once actual SAPE 2022 are released
+dz11_base_2021 <- dz11_base |>
+  filter(year==2021) |>
+  mutate(year=2022)
+
+dz11_base <-rbind(dz11_base,dz11_base_2021)
+rm(dz11_base_2021)
+ 
 saveRDS(dz11_base, file=paste0(pop_lookup, "DZ11_pop_basefile.rds"))
 dz11_base <- readRDS(paste0(pop_lookup, "DZ11_pop_basefile.rds"))
+
 
 ###############################################.
 # Intermediate zones, councils, health boards and HSC partnerships
@@ -192,8 +204,16 @@ dz11_base <- readRDS(paste0(pop_lookup, "DZ11_pop_basefile.rds"))
 hscp_pop <- extract_open_data("c3a393ce-253b-4c75-82dc-06b1bb5638a3", hscp) 
 hb_pop <- extract_open_data("27a72cc8-d6d8-430c-8b4f-3109a9ceadb1", hb) 
 ca_pop <- extract_open_data("09ebfefb-33f4-4f6a-8312-2d14e2b02ace", ca) 
-iz11_pop <- extract_open_data("93df4c88-f74b-4630-abd8-459a19b12f47", intzone) 
 iz01_pop <- extract_open_data("0bb11b73-27ad-45ed-9a35-df688d69b12b", intzone)
+
+iz11_pop <- extract_open_data("93df4c88-f74b-4630-abd8-459a19b12f47", intzone) 
+#temporary fix for delayed 2022 SAPE 
+#recycle 2021 populations as if they were the new 2022 populations - this will need to be revised & reupdated once actual SAPE 2022 are released
+iz11_pop_2021  <- iz11_pop|>
+  filter(year==2021) |>
+  mutate(year=2022)
+iz11_pop <-rbind(iz11_pop,iz11_pop_2021)
+rm(iz11_pop_2021)
 
 ###############################################.
 #Scotland population

--- a/population_lookup.R
+++ b/population_lookup.R
@@ -16,12 +16,6 @@ library(jsonlite)  # transforming JSON files into dataframes
 library(readr)
 
 # Varies filepaths depending on if using server or not and what organisation uses it.
-if (exists("organisation") == TRUE) { #Health Scotland
-  if (organisation == "HS") { 
-    pop_lookup <- "X:/ScotPHO Profiles/Data/Lookups/Population/"
-    geo_lookup <- "X:/ScotPHO Profiles/Data/Lookups/Geography/"
-  }
-} else  { #ISD, first server then desktop
   if (sessionInfo()$platform %in% c("x86_64-redhat-linux-gnu (64-bit)", "x86_64-pc-linux-gnu (64-bit)")) {
     pop_lookup <- "/PHI_conf/ScotPHO/Profiles/Data/Lookups/Population/"
     geo_lookup <- "/PHI_conf/ScotPHO/Profiles/Data/Lookups/Geography/"
@@ -29,7 +23,6 @@ if (exists("organisation") == TRUE) { #Health Scotland
     pop_lookup <- "//stats/ScotPHO/Profiles/Data/Lookups/Population/"
     geo_lookup <- "//stats/ScotPHO/Profiles/Data/Lookups/Geography/"
   }
-}
 
 # Setting file permissions to anyone to allow writing/overwriting of project files
 Sys.umask("006")

--- a/population_lookup.R
+++ b/population_lookup.R
@@ -178,12 +178,12 @@ dz11_base <- read_csv("https://www.opendata.nhs.scot/dataset/7f010430-6ce1-4813-
   rename(sex_grp = sex, denominator = pop, datazone2011 = datazone)
 
 ##temporary fix for delayed 2022 SAPE 
-#recycle 2021 populations as if they were the new 2022 populations - this will need to be revised & reupdated once actual SAPE 2022 are released
-dz11_base_2021 <- dz11_base |>
-  filter(year==2021) |>
-  mutate(year=2022)
+#recycle 2022 populations as if they were the new 2023 populations -
+dz11_base_2022 <- dz11_base |>
+  filter(year==2022) |> # filter for latest year
+  mutate(year=2023) # mutate latest year so that it will appear as 2023 
 
-dz11_base <-rbind(dz11_base,dz11_base_2021)
+dz11_base <-rbind(dz11_base,dz11_base_2022)
 rm(dz11_base_2021)
  
 saveRDS(dz11_base, file=paste0(pop_lookup, "DZ11_pop_basefile.rds"))

--- a/population_lookup.R
+++ b/population_lookup.R
@@ -381,6 +381,8 @@ saveRDS(teenpreg_pop_depr, file=paste0(pop_lookup, 'depr_pop_fem15to19.rds'))
 
 ###############################################.
 # Live births (used for infant deaths under 1)
+# received data requested from NRS 
+
 live_births <- readxl::read_excel(paste0("/PHI_conf/ScotPHO/Profiles/Data/Received Data/",
                                  "Births 2002-2021 datazone_2011.xlsx")) %>%
   janitor::clean_names() %>% 
@@ -388,8 +390,6 @@ live_births <- readxl::read_excel(paste0("/PHI_conf/ScotPHO/Profiles/Data/Receiv
   group_by(year, datazone) %>% 
   summarise(denominator = sum(count, na.rm = T)) %>% ungroup
   
-
-
 
 live_lookup <- readRDS(paste0(geo_lookup, "DataZone11_All_Geographies_Lookup.rds")) %>% 
   select(datazone2011, ca2019, hb2019, hscp2019) %>% 

--- a/population_lookup.R
+++ b/population_lookup.R
@@ -167,7 +167,8 @@ rm(dz01_base) #freeing up memory
 
 # Alternative code chunk (the function to open files and manipulation direct from API doesn't like running in posit ?too memory intensive?)
 # If the previous one times out/fails try this, but the link might change every year
-dz11_base <- read_csv("https://www.opendata.nhs.scot/dataset/7f010430-6ce1-4813-b25c-f7f335bdc4dc/resource/c505f490-c201-44bd-abd1-1bd7a64285ee/download/dz2011-pop-est_07092021.csv") %>%
+#dz11_base <- read_csv("https://www.opendata.nhs.scot/dataset/7f010430-6ce1-4813-b25c-f7f335bdc4dc/resource/c505f490-c201-44bd-abd1-1bd7a64285ee/download/dz2011-pop-est_07092021.csv") %>%
+dz11_base <- read_csv("https://www.opendata.nhs.scot/dataset/7f010430-6ce1-4813-b25c-f7f335bdc4dc/resource/c505f490-c201-44bd-abd1-1bd7a64285ee/download/dz2011-pop-est_21112024.csv") %>%
   setNames(tolower(names(.))) %>%   #variables to lower case
   filter(year > 2001 & substr(datazone, 1, 3) != "S92" & sex != "All") %>% #years and no Scotland
   mutate(sex = recode(sex, "Male" = 1, "Female" = 2, "f" = 2, "m" = 1)) %>%
@@ -184,11 +185,10 @@ dz11_base_2022 <- dz11_base |>
   mutate(year=2023) # mutate latest year so that it will appear as 2023 
 
 dz11_base <-rbind(dz11_base,dz11_base_2022)
-rm(dz11_base_2021)
+rm(dz11_base_2022)
  
 saveRDS(dz11_base, file=paste0(pop_lookup, "DZ11_pop_basefile.rds"))
 dz11_base <- readRDS(paste0(pop_lookup, "DZ11_pop_basefile.rds"))
-
 
 ###############################################.
 # Intermediate zones, councils, health boards and HSC partnerships
@@ -202,11 +202,11 @@ iz01_pop <- extract_open_data("0bb11b73-27ad-45ed-9a35-df688d69b12b", intzone)
 iz11_pop <- extract_open_data("93df4c88-f74b-4630-abd8-459a19b12f47", intzone) 
 #temporary fix for delayed 2022 SAPE 
 #recycle 2021 populations as if they were the new 2022 populations - this will need to be revised & reupdated once actual SAPE 2022 are released
-iz11_pop_2021  <- iz11_pop|>
-  filter(year==2021) |>
-  mutate(year=2022)
-iz11_pop <-rbind(iz11_pop,iz11_pop_2021)
-rm(iz11_pop_2021)
+iz11_pop_2022  <- iz11_pop|>
+  filter(year==2022) |>
+  mutate(year=2023)
+iz11_pop <-rbind(iz11_pop,iz11_pop_2022)
+rm(iz11_pop_2022)
 
 ###############################################.
 #Scotland population

--- a/population_lookups_CA_level.R
+++ b/population_lookups_CA_level.R
@@ -1,0 +1,193 @@
+##################################
+# Analyst notes ---
+##################################
+
+# This script creates population lookups using council area (CA) population estimates
+# NRS typically release CA estimates first, and then small area population estimates (SAPE) a few months later
+# However, there has been a significant delay in the release of 2022 SAPEs
+# This script can therefore be run to create population estimates at CA, HB, HSCP, ADP and Scotland level whilst waiting on SAPEs to be released
+
+# This allows a number of indicators to be updated where population estimates are used as the denominator,
+# and where they are not released at intermediate zone or locality level (i.e. dependent on SAPEs)
+
+# Indicators which can be updated (with name of lookup file required to carry out update):-
+
+# COPD incidence - CA_pop_16_SR+
+# COPD deaths - CA_pop_16+_SR
+# Alcohol-related hospital admissions , aged 11-25 years - CA_pop_11to25_SR
+# Children hospitalised due to asthma, aged 11-25 years - CA_pop_under16_SR
+# Deaths from suicide, female - CA_pop_allages_SR
+# Deaths from suicide, male - CA_pop_allages_SR
+# Deaths from suicide, aged 11-25 years - CA_pop_11to25
+# drug related hospital admissions - CA_pop_11to25_SR
+# Drug-related hospital admissions - CA_pop_allages_SR
+# Lung cancer deaths - CA_pop_16+_SR
+# Lung cancer registrations - CA_pop_16+_SR
+# Unintentional unjuries inunder 5s – CA_pop_under5_SR
+# Young people admitted to hospital due to assault - CA_pop_15to25_SR
+# Drug-related deaths, all - CA_pop_all_ages_R
+# Drug-related deaths, females - CA_pop_allages_SR
+# Drug-related deaths, males - CA_pop_allages_SR
+# Smoking Attributable admissions – CA_pop_all_ages_SR
+# Smoking Attrbutable deaths – CA_pop_all_ages_SR
+
+
+########################################################
+# Lookups which need updated to update these indicators:
+########################################################
+
+# CA_pop_allages_SR 
+# CA_pop_16+_SR
+# CA_pop_11to25_SR
+# CA_pop_11to25 (version used for crude rates)
+# CA_pop_under16_SR
+# CA_pop_15to25_SR
+# CA_pop_under5_SR
+
+
+########################
+# packages
+#########################
+library(dplyr)
+library(tidyr)
+
+
+########################
+# filepaths
+########################
+cl_out <- "/conf/linkage/output/lookups/Unicode/Populations/Estimates/" #cl-out folderwith new 2022 estimates
+scotpho_lookups_folder <- "/PHI_conf/ScotPHO/Profiles/Data/Lookups/" # scotpho folder where geography and population lookups are saved
+
+
+##########################
+# Lookups 
+###########################
+
+# geography lookup 
+geo_lookup<- readRDS(paste0(scotpho_lookups_folder, "Geography/DataZone11_All_Geographies_Lookup.rds")) |>
+  select(ca2019, hscp2019, hb2019, adp) |>
+  unique()
+
+# new council area population estimates
+CA_estimates_raw<- readRDS(paste0(cl_out, "CA2019_pop_est_1981_2022.rds")) |>
+  filter(year >= 2002)
+
+
+
+###################################################################
+# Functions
+###################################################################
+
+
+# function to create SR population lookups for different age groups
+create_population_lookup <- function(lower_age, upper_age, basefile = CA_estimates_raw, geography_lookup = geo_lookup){
+  
+  # step 1: filter by age
+  # note this needs to be done first before creating age group column 
+  # so that for example, if trying to create a population 16+ file, the age 15 is removed from the '15-19' grouping
+  CA_estimates <- basefile |>
+    filter(age >= lower_age & age <= upper_age)
+  
+  # step 2: create age group column required for calculating standardised rates
+  CA_estimates <- CA_estimates |>
+    mutate(age_grp = case_when(
+      age < 5 ~ 1, age > 4 & age <10 ~ 2, age > 9 & age <15 ~ 3, age > 14 & age <20 ~ 4,
+      age > 19 & age <25 ~ 5, age > 24 & age <30 ~ 6, age > 29 & age <35 ~ 7,
+      age > 34 & age <40 ~ 8, age > 39 & age <45 ~ 9, age > 44 & age <50 ~ 10,
+      age > 49 & age <55 ~ 11, age > 54 & age <60 ~ 12, age > 59 & age <65 ~ 13,
+      age > 64 & age <70 ~ 14, age > 69 & age <75 ~ 15, age > 74 & age <80 ~ 16,
+      age > 79 & age <85 ~ 17, age > 84 & age <90 ~ 18, age > 89 ~ 19,
+      TRUE ~ as.numeric(age)
+    ))
+  
+  
+  # step 3: select required columns
+  CA_estimates <- CA_estimates |>
+    select(year, ca2019, sex, age_grp, pop)
+  
+  
+  # step 4: attach other geography levels (HB, ADP, HSCP, Scotland)
+  CA_estimates <- CA_estimates |>
+    left_join(geography_lookup, by = "ca2019") |>
+    mutate(Scotland = "S00000001")
+  
+  
+  # step 5: pivot the data longer to create a geography code column
+  # and sum the population estimates for each geography code
+  CA_estimates <- CA_estimates |>
+    pivot_longer(cols = c(ca2019, hscp2019, hb2019, adp, Scotland),
+                 names_to = "area_type",
+                 values_to = "code") |>
+    group_by(age_grp, sex, year, code) |>
+    summarize(pop = sum(pop), .groups = 'drop')
+  
+  # step 6: rename columns as required to be used in scotpho analysis functions
+  CA_estimates <- CA_estimates |>
+    rename(denominator = pop,
+           sex_grp = sex)
+  
+  return(CA_estimates)
+  
+}
+
+
+
+# function to check the historic data in the newly createed lookup against the old lookup saved in the scotpho folder
+dq_check <- function(old_file, new_data){
+  
+  old_estimates <- readRDS(paste0(scotpho_lookups_folder, "Population/", old_file, ".rds"))
+  
+  check <- left_join(old_estimates, new_data, by = c("year", "sex_grp", "age_grp", "code")) |>
+    mutate(number_diff = denominator.x - denominator.y,
+           percent_diff = (number_diff/denominator.x) * 100)
+}
+
+
+####################################
+# Create population lookups 
+###################################
+
+pop_all_ages <- create_population_lookup(lower_age = 0, upper_age = 90)
+pop_16_plus <- create_population_lookup(lower_age = 16, upper_age = 90)
+pop_11_to_25 <- create_population_lookup(lower_age = 11, upper_age = 25)
+pop_under_16 <- create_population_lookup(lower_age = 0, upper_age = 15)
+pop_under_5 <- create_population_lookup(lower_age = 0, upper_age = 4)
+pop_15_to_25 <- create_population_lookup(lower_age = 15, upper_age = 25)
+
+
+########################################################
+# Check historic data against old lookups before saving 
+########################################################
+
+pop_all_ages_check <- dq_check(new_data = pop_all_ages, old_file = "CA_pop_allages_SR")
+pop_16_plus_check <- dq_check(new_data = pop_16_plus, old_file = "CA_pop_16+_SR")
+pop_11_to_25_check <- dq_check(new_data = pop_11_to_25, old_file = "CA_pop_11to25_SR")
+pop_under_16_check <-  dq_check(new_data = pop_under_16, old_file = "CA_pop_under16_SR")
+pop_under_5_check <-  dq_check(new_data = pop_under_5, old_file = "CA_pop_under5_SR")
+pop_15_to_25_check <- dq_check(new_data = pop_15_to_25, old_file = "CA_pop_15to25_SR")
+
+
+# remove checks from global env
+rm(pop_all_ages_check, pop_16_plus_check, pop_11_to_25_check, pop_under_16_check, pop_under_5_check, pop_15_to_25_check)
+
+
+###############################################
+# save new lookups in temporary folder 
+##############################################
+saveRDS(pop_all_ages, paste0(scotpho_lookups_folder, "Population_workaround/CA_pop_allages_SR.rds"))
+saveRDS(pop_16_plus, paste0(scotpho_lookups_folder, "Population_workaround/CA_pop_16+_SR.rds"))
+saveRDS(pop_11_to_25, paste0(scotpho_lookups_folder, "Population_workaround/CA_pop_11to25_SR.rds"))
+saveRDS(pop_under_16, paste0(scotpho_lookups_folder, "Population_workaround/CA_pop_under16_SR.rds"))
+saveRDS(pop_under_5, paste0(scotpho_lookups_folder, "Population_workaround/CA_pop_under5_SR.rds"))
+saveRDS(pop_15_to_25, paste0(scotpho_lookups_folder, "Population_workaround/CA_pop_15to25_SR.rds"))
+
+###########################
+# create backups of old files 
+###########################
+
+
+# note: save the old files from the Population lookup folder into the 'backups' subfolder, then move these files
+# across to the population folder so they are ready to be used within the indicator analysis functions.
+
+
+

--- a/population_lookups_CA_level.R
+++ b/population_lookups_CA_level.R
@@ -23,7 +23,7 @@
 # COPD incidence
 # COPD deaths
 # Alcohol-related hospital admissions , aged 11-25 years
-# Children hospitalised due to asthma, aged 11-25 years
+# Children hospitalised due to asthma, aged 0-15 years
 # Deaths from suicide, female
 # Deaths from suicide, male
 # Deaths from suicide, aged 11-25 years
@@ -208,7 +208,6 @@ create_population_lookups(lower_age = 11, upper_age = 25, name = "11to25")
 create_population_lookups(lower_age = 0, upper_age = 15, name = "under16")
 create_population_lookups(lower_age = 0, upper_age = 4, name = "under5")
 create_population_lookups(lower_age = 15, upper_age = 25, name = "15to25")
-create_population_lookups(lower_age = 0, upper_age = 17, name = "under18")
 create_population_lookups(lower_age = 0, upper_age = 17, name = "under18")
 create_population_lookups(lower_age = 0, upper_age = 17, name = "1to15")
 create_population_lookups(lower_age = 12, upper_age = 90, name = "12+")

--- a/population_lookups_CA_level.R
+++ b/population_lookups_CA_level.R
@@ -1,6 +1,6 @@
-##################################
-# Analyst notes ---
-##################################
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+### 1. Analyst notes ----
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 # This script creates population lookups using council area (CA) population estimates
 # NRS typically release CA estimates first, and then small area population estimates (SAPE) a few months later
@@ -9,32 +9,39 @@
 
 # This allows a number of indicators to be updated where population estimates are used as the denominator,
 # and where they are not released at intermediate zone or locality level (i.e. dependent on SAPEs)
+# This is because we have different types of population lookups 
+# (i.e. datazone level lookups for calculating all areatypes including HSC localities and IZs
+# and higher geography level lookups containing only CA/HB/ADP/HSCP/Scotland)
 
-# Indicators which can be updated (with name of lookup file required to carry out update):-
-
-# COPD incidence - CA_pop_16_SR+
-# COPD deaths - CA_pop_16+_SR
-# Alcohol-related hospital admissions , aged 11-25 years - CA_pop_11to25_SR
-# Children hospitalised due to asthma, aged 11-25 years - CA_pop_under16_SR
-# Deaths from suicide, female - CA_pop_allages_SR
-# Deaths from suicide, male - CA_pop_allages_SR
-# Deaths from suicide, aged 11-25 years - CA_pop_11to25
-# drug related hospital admissions - CA_pop_11to25_SR
-# Drug-related hospital admissions - CA_pop_allages_SR
-# Lung cancer deaths - CA_pop_16+_SR
-# Lung cancer registrations - CA_pop_16+_SR
-# Unintentional unjuries inunder 5s – CA_pop_under5_SR
-# Young people admitted to hospital due to assault - CA_pop_15to25_SR
-# Drug-related deaths, all - CA_pop_all_ages_R
-# Drug-related deaths, females - CA_pop_allages_SR
-# Drug-related deaths, males - CA_pop_allages_SR
-# Smoking Attributable admissions – CA_pop_all_ages_SR
-# Smoking Attrbutable deaths – CA_pop_all_ages_SR
+# there are therefore a number of indicators where the population lookup passed to the analysis functions are those higher geo level lookups:
 
 
-########################################################
+# Indicators which can be updated prior to release of SAPEs:-
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# COPD incidence
+# COPD deaths
+# Alcohol-related hospital admissions , aged 11-25 years
+# Children hospitalised due to asthma, aged 11-25 years
+# Deaths from suicide, female
+# Deaths from suicide, male
+# Deaths from suicide, aged 11-25 years
+# drug related hospital admissions
+# Drug-related hospital admissions
+# Lung cancer deaths
+# Lung cancer registrations
+# Unintentional unjuries inunder 5s
+# Young people admitted to hospital due to assault
+# Drug-related deaths, all
+# Drug-related deaths, females
+# Drug-related deaths, males
+# Smoking Attributable admissions
+# Smoking Attrbutable deaths
+
+
+
 # Lookups which need updated to update these indicators:
-########################################################
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 # CA_pop_allages_SR 
 # CA_pop_16+_SR
@@ -45,39 +52,37 @@
 # CA_pop_under5_SR
 
 
-########################
-# packages
-#########################
+# ~~~~~~~~~~~~~~~~~~~~~~~~
+# 2. Housekeeping ----
+# ~~~~~~~~~~~~~~~~~~~~~~~~
+
+## packages ----
 library(dplyr)
 library(tidyr)
 
-
-########################
-# filepaths
-########################
+## filepaths ----
 cl_out <- "/conf/linkage/output/lookups/Unicode/Populations/Estimates/" #cl-out folderwith new 2022 estimates
 scotpho_lookups_folder <- "/PHI_conf/ScotPHO/Profiles/Data/Lookups/" # scotpho folder where geography and population lookups are saved
 
 
-##########################
-# Lookups 
-###########################
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~
+# 3. Lookups ----
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-# geography lookup 
+## geography lookup 
 geo_lookup<- readRDS(paste0(scotpho_lookups_folder, "Geography/DataZone11_All_Geographies_Lookup.rds")) |>
   select(ca2019, hscp2019, hb2019, adp) |>
   unique()
 
-# new council area population estimates
+## new council area population estimates
 CA_estimates_raw<- readRDS(paste0(cl_out, "CA2019_pop_est_1981_2022.rds")) |>
   filter(year >= 2002)
 
 
 
-###################################################################
-# Functions
-###################################################################
-
+# ~~~~~~~~~~~~~~~~~~~~~~
+### 3. Functions ----
+# ~~~~~~~~~~~~~~~~~~~~~~~
 
 # function to create SR population lookups for different age groups
 create_population_lookup <- function(lower_age, upper_age, basefile = CA_estimates_raw, geography_lookup = geo_lookup){
@@ -143,9 +148,9 @@ dq_check <- function(old_file, new_data){
 }
 
 
-####################################
-# Create population lookups 
-###################################
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# 4.  Create population lookups ----
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 pop_all_ages <- create_population_lookup(lower_age = 0, upper_age = 90)
 pop_16_plus <- create_population_lookup(lower_age = 16, upper_age = 90)
@@ -155,9 +160,9 @@ pop_under_5 <- create_population_lookup(lower_age = 0, upper_age = 4)
 pop_15_to_25 <- create_population_lookup(lower_age = 15, upper_age = 25)
 
 
-########################################################
-# Check historic data against old lookups before saving 
-########################################################
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# 5. Check historic data against old lookups  ----
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 pop_all_ages_check <- dq_check(new_data = pop_all_ages, old_file = "CA_pop_allages_SR")
 pop_16_plus_check <- dq_check(new_data = pop_16_plus, old_file = "CA_pop_16+_SR")
@@ -171,9 +176,9 @@ pop_15_to_25_check <- dq_check(new_data = pop_15_to_25, old_file = "CA_pop_15to2
 rm(pop_all_ages_check, pop_16_plus_check, pop_11_to_25_check, pop_under_16_check, pop_under_5_check, pop_15_to_25_check)
 
 
-###############################################
-# save new lookups in temporary folder 
-##############################################
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# 6. save new lookups in temporary folder ---
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 saveRDS(pop_all_ages, paste0(scotpho_lookups_folder, "Population_workaround/CA_pop_allages_SR.rds"))
 saveRDS(pop_16_plus, paste0(scotpho_lookups_folder, "Population_workaround/CA_pop_16+_SR.rds"))
 saveRDS(pop_11_to_25, paste0(scotpho_lookups_folder, "Population_workaround/CA_pop_11to25_SR.rds"))
@@ -181,10 +186,9 @@ saveRDS(pop_under_16, paste0(scotpho_lookups_folder, "Population_workaround/CA_p
 saveRDS(pop_under_5, paste0(scotpho_lookups_folder, "Population_workaround/CA_pop_under5_SR.rds"))
 saveRDS(pop_15_to_25, paste0(scotpho_lookups_folder, "Population_workaround/CA_pop_15to25_SR.rds"))
 
-###########################
-# create backups of old files 
-###########################
-
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# 7. create backups of old files ---
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 # note: save the old files from the Population lookup folder into the 'backups' subfolder, then move these files
 # across to the population folder so they are ready to be used within the indicator analysis functions.


### PR DESCRIPTION
Hi both,

I've made this small script so that we can start updating some indicators which were put on hold due to delays to 2022 population estimates, that don't go down to IZ/HSC locality level. There is a note at the top of the script which will explain in more detail.

In short, there's a bunch of indicators (around 20 of which are SMR related) where the population lookup file passed to the analysis function only contains CA/HB/HSCP/Scotland estimates. I've re-recreated some of those lookups using the latest CA 2022 estimates so we can start updating some indicators that don't go down to IZ/HSC locality level without waiting for SAPE 2022.

We could start with prioritising some of the SMR ones so they could maybe get deployed alongside the new tool? (I've already updated 7 of them)

@abigap01 I'll explain all of this in more detail in our catch-up!

