### PR TITLE
ER - Adding police divisions to geography lookups

### DIFF
--- a/population_lookup.R
+++ b/population_lookup.R
@@ -15,21 +15,9 @@ library(httr) # api connection
 library(jsonlite)  # transforming JSON files into dataframes
 library(readr)
 
-# Varies filepaths depending on if using server or not and what organisation uses it.
-if (exists("organisation") == TRUE) { #Health Scotland
-  if (organisation == "HS") { 
-    pop_lookup <- "X:/ScotPHO Profiles/Data/Lookups/Population/"
-    geo_lookup <- "X:/ScotPHO Profiles/Data/Lookups/Geography/"
-  }
-} else  { #ISD, first server then desktop
-  if (sessionInfo()$platform %in% c("x86_64-redhat-linux-gnu (64-bit)", "x86_64-pc-linux-gnu (64-bit)")) {
-    pop_lookup <- "/PHI_conf/ScotPHO/Profiles/Data/Lookups/Population/"
-    geo_lookup <- "/PHI_conf/ScotPHO/Profiles/Data/Lookups/Geography/"
-  } else {
-    pop_lookup <- "//stats/ScotPHO/Profiles/Data/Lookups/Population/"
-    geo_lookup <- "//stats/ScotPHO/Profiles/Data/Lookups/Geography/"
-  }
-}
+# Lookups
+pop_lookup <- "/PHI_conf/ScotPHO/Profiles/Data/Lookups/Population/"
+geo_lookup <- "/PHI_conf/ScotPHO/Profiles/Data/Lookups/Geography/"
 
 # Setting file permissions to anyone to allow writing/overwriting of project files
 Sys.umask("006")
@@ -100,7 +88,7 @@ create_pop <- function(lower, upper, name, dz) {
   saveRDS(data_dz, file=paste0(pop_lookup, dz, '_', name,'.rds'))
   
    # Creating file for indicators that need council as base
-    data_ca <- data_dz %>% subset(substr(code,1,3) %in% c('S00', 'S08', 'S12', "S11", "S37"))
+    data_ca <- data_dz %>% subset(substr(code,1,3) %in% c('S00', 'S08', 'S12', "S11", "S37", "S32"))
     
     saveRDS(data_ca, file=paste0(pop_lookup, 'CA_', name,'.rds'))
   
@@ -114,7 +102,7 @@ create_pop <- function(lower, upper, name, dz) {
     saveRDS(data_dz_sr, file=paste0(pop_lookup, dz, '_', name,'_SR.rds'))
     
     # Creating file for indicators that need council as base
-    data_ca_sr <- data_dz_sr %>% subset(substr(code,1,3) %in%  c('S00', 'S08', 'S12', "S11", "S37"))
+    data_ca_sr <- data_dz_sr %>% subset(substr(code,1,3) %in%  c('S00', 'S08', 'S12', "S11", "S37", "S32"))
       
       saveRDS(data_ca_sr, file=paste0(pop_lookup, 'CA_', name,'_SR.rds'))
   
@@ -184,14 +172,14 @@ dz11_base <- read_csv("https://www.opendata.nhs.scot/dataset/7f010430-6ce1-4813-
   create_agegroups()  %>%
   rename(sex_grp = sex, denominator = pop, datazone2011 = datazone)
 
-##temporary fix for delayed 2022 SAPE 
-#recycle 2021 populations as if they were the new 2022 populations - this will need to be revised & reupdated once actual SAPE 2022 are released
-dz11_base_2021 <- dz11_base |>
-  filter(year==2021) |>
-  mutate(year=2022)
+##temporary fix for delayed SAPE data
+#recycle 2023 populations as if they were the new 2024 populations - this will need to be revised & reupdated once actual SAPE 2024 are released
+dz11_base_2023 <- dz11_base |>
+  filter(year==2023) |>
+  mutate(year=2024)
 
-dz11_base <-rbind(dz11_base,dz11_base_2021)
-rm(dz11_base_2021)
+dz11_base <-rbind(dz11_base,dz11_base_2023)
+rm(dz11_base_2023)
  
 saveRDS(dz11_base, file=paste0(pop_lookup, "DZ11_pop_basefile.rds"))
 dz11_base <- readRDS(paste0(pop_lookup, "DZ11_pop_basefile.rds"))
@@ -207,13 +195,14 @@ ca_pop <- extract_open_data("09ebfefb-33f4-4f6a-8312-2d14e2b02ace", ca)
 iz01_pop <- extract_open_data("0bb11b73-27ad-45ed-9a35-df688d69b12b", intzone)
 
 iz11_pop <- extract_open_data("93df4c88-f74b-4630-abd8-459a19b12f47", intzone) 
-#temporary fix for delayed 2022 SAPE 
-#recycle 2021 populations as if they were the new 2022 populations - this will need to be revised & reupdated once actual SAPE 2022 are released
-iz11_pop_2021  <- iz11_pop|>
-  filter(year==2021) |>
-  mutate(year=2022)
-iz11_pop <-rbind(iz11_pop,iz11_pop_2021)
-rm(iz11_pop_2021)
+
+#temporary fix for delayed SAPE data
+#recycle 2023 populations as if they were the new 2024 populations - this will need to be revised & reupdated once actual SAPE 2024 are released
+iz11_pop_2023  <- iz11_pop|>
+  filter(year==2023) |>
+  mutate(year=2024)
+iz11_pop <-rbind(iz11_pop,iz11_pop_2023)
+rm(iz11_pop_2023)
 
 ###############################################.
 #Scotland population
@@ -249,14 +238,94 @@ adp_pop <- ca_pop %>%
   summarise(pop = sum(pop)) %>% ungroup()
 
 ###############################################.
+# PD population
+
+# Creating lookup of PDs with council area
+pd_lookup <- data.frame(
+  ca2019 = c("S12000005",
+             "S12000006",
+             "S12000008",
+             "S12000010",
+             "S12000011",
+             "S12000013",
+             "S12000014",
+             "S12000017",
+             "S12000018",
+             "S12000019",
+             "S12000020",
+             "S12000021",
+             "S12000023",
+             "S12000026",
+             "S12000027",
+             "S12000028",
+             "S12000029",
+             "S12000030",
+             "S12000033",
+             "S12000034",
+             "S12000035",
+             "S12000036",
+             "S12000038",
+             "S12000039",
+             "S12000040",
+             "S12000041",
+             "S12000042",
+             "S12000045",
+             "S12000047",
+             "S12000048",
+             "S12000049",
+             "S12000050"
+  ),
+  pd = c("S32000008",
+         "S32000005",
+         "S32000004",
+         "S32000012",
+         "S32000018",
+         "S32000010",
+         "S32000008",
+         "S32000010",
+         "S32000013",
+         "S32000012",
+         "S32000015",
+         "S32000004",
+         "S32000010",
+         "S32000012",
+         "S32000010",
+         "S32000004",
+         "S32000019",
+         "S32000008",
+         "S32000015",
+         "S32000015",
+         "S32000003",
+         "S32000006",
+         "S32000013",
+         "S32000003",
+         "S32000012",
+         "S32000017",
+         "S32000017",
+         "S32000018",
+         "S32000016",
+         "S32000017",
+         "S32000018",
+         "S32000019"
+  ))
+
+pd_pop <- ca_pop %>% 
+  merge(y=pd_lookup, by.x="code", by.y="ca2019") %>%
+  group_by(year, sex_grp, age, pd) %>%
+  summarise(pop = sum(pop)) %>%
+  ungroup() %>%
+  rename(code = pd)
+  
+
+###############################################.
 #merging all geographical levels
-all_pop01 <- rbind(iz01_pop, ca_pop, adp_pop, hb_pop, hscp_pop, scot_pop, local_pop) %>% 
+all_pop01 <- rbind(iz01_pop, ca_pop, adp_pop, pd_pop, hb_pop, hscp_pop, scot_pop, local_pop) %>% 
   rename(denominator=pop) %>% create_agegroups() %>% #recoding age
   mutate(year = as.numeric(year))
 
 saveRDS(all_pop01, file=paste0(pop_lookup, "basefile_DZ01.rds"))
 
-all_pop11 <- rbind(iz11_pop, ca_pop, adp_pop, hb_pop, hscp_pop, scot_pop, local_pop) %>% 
+all_pop11 <- rbind(iz11_pop, ca_pop, adp_pop, pd_pop, hb_pop, hscp_pop, scot_pop, local_pop) %>% 
   rename(denominator=pop) %>% create_agegroups() %>%  #recoding age
   mutate(year = as.numeric(year))
 
@@ -310,6 +379,7 @@ create_pop(dz = "DZ11", lower = 0, upper = 200, name = "pop_allages")
 create_pop(dz = "DZ11", lower = 60, upper = 200, name = "pop_60+")
 create_pop(dz = "DZ11", lower = 16, upper = 200, name = "pop_16+")
 create_pop(dz = "DZ11", lower = 18, upper = 200, name = "pop_18+")
+create_pop(dz = "DZ11", lower = 19, upper = 200, name = "pop_19+")
 create_pop(dz = "DZ11", lower = 65, upper = 200, name = "pop_65+")
 create_pop(dz = "DZ11", lower = 75, upper = 200, name = "pop_75+")
 create_pop(dz = "DZ11", lower = 85, upper = 200, name = "pop_85+")
@@ -347,7 +417,7 @@ working_pop <- readRDS(file=paste0(pop_lookup, "basefile_DZ11.rds")) %>%
 saveRDS(working_pop, file=paste0(pop_lookup, 'DZ11_working_pop.rds'))
 
 # For CA
-working_pop <- working_pop %>% subset(substr(code,1,3) %in% c('S00', 'S08', 'S12', 'S37'))
+working_pop <- working_pop %>% subset(substr(code,1,3) %in% c('S00', 'S08', 'S12', 'S37', 'S32'))
 saveRDS(working_pop, file=paste0(pop_lookup, 'CA_working_pop.rds'))
 
 #For deprivation cases
@@ -368,7 +438,7 @@ teenpreg_pop <- readRDS(file=paste0(pop_lookup, "basefile_DZ11.rds")) %>%
 
 saveRDS(teenpreg_pop, file=paste0(pop_lookup, 'DZ11_pop_fem15to19.rds'))
 
-teenpreg_pop <- teenpreg_pop %>% subset(substr(code,1,3) %in% c('S00', 'S08', 'S12', 'S37'))
+teenpreg_pop <- teenpreg_pop %>% subset(substr(code,1,3) %in% c('S00', 'S08', 'S12', 'S37', 'S32'))
 saveRDS(teenpreg_pop, file=paste0(pop_lookup, 'CA_pop_fem15to19.rds'))
 
 #For deprivation cases
@@ -383,8 +453,8 @@ saveRDS(teenpreg_pop_depr, file=paste0(pop_lookup, 'depr_pop_fem15to19.rds'))
 # Live births (used for infant deaths under 1)
 # received data requested from NRS 
 
-live_births <- readxl::read_excel(paste0("/PHI_conf/ScotPHO/Profiles/Data/Received Data/",
-                                 "Births 2002-2021 datazone_2011.xlsx")) %>%
+live_births <- readxl::read_excel(paste0("/PHI_conf/ScotPHO/Profiles/Data/Received Data/Live births/",
+                                 "Births 2002-2023 datazone_2011.xlsx")) %>%
   janitor::clean_names() %>% 
   rename(datazone = datazone_2011, year = registration_year) %>% 
   group_by(year, datazone) %>% 
@@ -392,7 +462,7 @@ live_births <- readxl::read_excel(paste0("/PHI_conf/ScotPHO/Profiles/Data/Receiv
   
 
 live_lookup <- readRDS(paste0(geo_lookup, "DataZone11_All_Geographies_Lookup.rds")) %>% 
-  select(datazone2011, ca2019, hb2019, hscp2019) %>% 
+  select(datazone2011, ca2019, hb2019, hscp2019, adp, pd) %>% 
   mutate(scot = "S00000001")
 
 live_births <- left_join(live_births, live_lookup, by = c("datazone" = "datazone2011"))

--- a/population_lookups_CA_level.R
+++ b/population_lookups_CA_level.R
@@ -88,7 +88,7 @@ library(dplyr)
 library(tidyr)
 
 ## filepaths ----
-cl_out <- "/conf/linkage/output/lookups/Unicode/Populations/Estimates/" #cl-out folderwith new 2022 estimates
+cl_out <- "/conf/linkage/output/lookups/Unicode/Populations/Estimates/" #cl-out folderwith new 2023 estimates
 scotpho_lookups_folder <- "/PHI_conf/ScotPHO/Profiles/Data/Lookups/" # scotpho folder where geography and population lookups are saved
 
 
@@ -98,11 +98,11 @@ scotpho_lookups_folder <- "/PHI_conf/ScotPHO/Profiles/Data/Lookups/" # scotpho f
 
 ## geography lookup 
 geo_lookup<- readRDS(paste0(scotpho_lookups_folder, "Geography/DataZone11_All_Geographies_Lookup.rds")) |>
-  select(ca2019, hscp2019, hb2019, adp) |>
+  select(ca2019, hscp2019, hb2019, adp, pd) |>
   unique()
 
 ## new council area population estimates
-CA_estimates_raw<- readRDS(paste0(cl_out, "CA2019_pop_est_1981_2022.rds")) |>
+CA_estimates_raw<- readRDS(paste0(cl_out, "CA2019_pop_est_1981_2023.rds")) |>
   filter(year >= 2002)
 
 
@@ -204,6 +204,7 @@ dq_check <- function(filename){
 
 create_population_lookups(lower_age = 0, upper_age = 90, name = "allages")
 create_population_lookups(lower_age = 16, upper_age = 90, name = "16+")
+create_population_lookups(lower_age = 19, upper_age = 90, name = "19+")
 create_population_lookups(lower_age = 11, upper_age = 25, name = "11to25")
 create_population_lookups(lower_age = 0, upper_age = 15, name = "under16")
 create_population_lookups(lower_age = 0, upper_age = 4, name = "under5")


### PR DESCRIPTION
Haven't added PDs into the shapefiles script, as there's already a PD shapefile in the shapefiles folder (and I'm out of brain capacity).

I also edited the function to create the SIMD lookup, to add in HSCP-specific quintiles, as well as ADPs and police divisions. The deprivation analysis script in indicator prep repo states that we only prepare inequalities data for Scotland, HBs and CAs, because other geogs are smaller. But HSCPs, ADPs, and PDs are larger than CAs, so this is why I have added them here. Feel free to disregard if there was another reason not to prep inequalities info for these geogs. 

Area-specific quintiles: An HSCP-quintile button could be added to the app now. Although not provided in the routine PHS data we could derive quintiles specific to ADPs and PDs too.